### PR TITLE
feat #7 - 지출 컨설팅 API 구현

### DIFF
--- a/src/main/java/com/wonjung/budget/controller/ConsultingController.java
+++ b/src/main/java/com/wonjung/budget/controller/ConsultingController.java
@@ -1,0 +1,36 @@
+package com.wonjung.budget.controller;
+
+import com.wonjung.budget.dto.response.ExpenseRecommendDto;
+import com.wonjung.budget.dto.response.FeedbackDto;
+import com.wonjung.budget.entity.Member;
+import com.wonjung.budget.security.AuthenticationPrincipal;
+import com.wonjung.budget.service.ConsultingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/expenses")
+@RequiredArgsConstructor
+public class ConsultingController {
+
+    private final ConsultingService consultingService;
+
+    @GetMapping("/todays-feedback")
+    public ResponseEntity<FeedbackDto> getFeedbackExpenseOfToday(
+            @AuthenticationPrincipal Member member
+    ) {
+        FeedbackDto feedbackDto = consultingService.getFeedbackExpenseOfToday(member);
+        return ResponseEntity.ok(feedbackDto);
+    }
+
+    @GetMapping("/todays-recommend")
+    public ResponseEntity<ExpenseRecommendDto> getRecommendExpenseOfToday(
+            @AuthenticationPrincipal Member member
+    ) {
+        ExpenseRecommendDto recommendDto = consultingService.getRecommendExpenseOfToday(member);
+        return ResponseEntity.ok(recommendDto);
+    }
+}

--- a/src/main/java/com/wonjung/budget/dto/response/ExpenseRecommendDto.java
+++ b/src/main/java/com/wonjung/budget/dto/response/ExpenseRecommendDto.java
@@ -1,0 +1,7 @@
+package com.wonjung.budget.dto.response;
+
+public record ExpenseRecommendDto(
+        Integer budget,
+        String ment
+) {
+}

--- a/src/main/java/com/wonjung/budget/dto/response/FeedbackDto.java
+++ b/src/main/java/com/wonjung/budget/dto/response/FeedbackDto.java
@@ -1,0 +1,17 @@
+package com.wonjung.budget.dto.response;
+
+import java.util.List;
+
+public record FeedbackDto(
+        Integer budget,
+        Integer expense,
+        Integer risk,
+        List<CategoryExpenseDto> categories
+) {
+    public record CategoryExpenseDto(
+            String category,
+            Integer expense
+    ) {
+
+    }
+}

--- a/src/main/java/com/wonjung/budget/exception/ErrorCode.java
+++ b/src/main/java/com/wonjung/budget/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
 
     // BUDGET
     NEED_ALL_CATEGORIES(HttpStatus.BAD_REQUEST, "모든 카테고리를 포함해야 합니다."),
+    NO_BUDGET(HttpStatus.NOT_FOUND, "설정된 예산 정보가 없습니다. 예산을 먼저 설정해주세요."),
 
 
     // -------- 5xx Error --------

--- a/src/main/java/com/wonjung/budget/repository/BudgetRepository.java
+++ b/src/main/java/com/wonjung/budget/repository/BudgetRepository.java
@@ -5,6 +5,7 @@ import com.wonjung.budget.entity.Category;
 import com.wonjung.budget.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,6 +14,9 @@ public interface BudgetRepository extends JpaRepository<Budget, Long>, BudgetRep
 
     @Query("select b from Budget b join fetch b.category")
     List<Budget> findAllByMemberWithCategory(Member member);
+
+    @Query("select sum(b.amount) from Budget b where b.member = :member")
+    Integer getAmountSumByMember(@Param("member") Member member);
 
     Optional<Budget> findByMemberAndCategory(Member member, Category category);
 }

--- a/src/main/java/com/wonjung/budget/repository/ExpenseRepositoryCustom.java
+++ b/src/main/java/com/wonjung/budget/repository/ExpenseRepositoryCustom.java
@@ -1,13 +1,17 @@
 package com.wonjung.budget.repository;
 
+import com.wonjung.budget.entity.Category;
 import com.wonjung.budget.entity.Expense;
 import com.wonjung.budget.entity.Member;
 import com.wonjung.budget.type.OrderStatus;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 
 public interface ExpenseRepositoryCustom {
     List<Expense> findAllByMember(Member member, LocalDate startDate, LocalDate endDate, int minAmount, int maxAmount,
                                   OrderStatus orderStatus, String search, List<String> categories);
+    Map<Category, Integer> getExpenseSumByMemberBetweenDateGroupByCategory(Member member, LocalDate startDate, LocalDate endDate);
+
 }

--- a/src/main/java/com/wonjung/budget/service/ConsultingService.java
+++ b/src/main/java/com/wonjung/budget/service/ConsultingService.java
@@ -1,0 +1,10 @@
+package com.wonjung.budget.service;
+
+import com.wonjung.budget.dto.response.ExpenseRecommendDto;
+import com.wonjung.budget.dto.response.FeedbackDto;
+import com.wonjung.budget.entity.Member;
+
+public interface ConsultingService {
+    FeedbackDto getFeedbackExpenseOfToday(Member member);
+    ExpenseRecommendDto getRecommendExpenseOfToday(Member member);
+}

--- a/src/main/java/com/wonjung/budget/service/impl/ConsultingServiceImpl.java
+++ b/src/main/java/com/wonjung/budget/service/impl/ConsultingServiceImpl.java
@@ -1,0 +1,132 @@
+package com.wonjung.budget.service.impl;
+
+import com.wonjung.budget.dto.response.ExpenseRecommendDto;
+import com.wonjung.budget.dto.response.FeedbackDto;
+import com.wonjung.budget.entity.Category;
+import com.wonjung.budget.entity.Member;
+import com.wonjung.budget.exception.CustomException;
+import com.wonjung.budget.exception.ErrorCode;
+import com.wonjung.budget.repository.BudgetRepository;
+import com.wonjung.budget.repository.ExpenseRepository;
+import com.wonjung.budget.service.ConsultingService;
+import com.wonjung.budget.type.ConsultingMent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ConsultingServiceImpl implements ConsultingService {
+
+    private static final int MIN_BUDGET_OF_DAY = 10000;
+
+    private final BudgetRepository budgetRepository;
+    private final ExpenseRepository expenseRepository;
+
+    // 오늘 지출한 총액과 카테고리별 금액 반환
+    @Override
+    public FeedbackDto getFeedbackExpenseOfToday(Member member) {
+        // 오늘 추천 예산
+        LocalDate today = LocalDate.now();
+        int expenseSumUntilYesterday = getExpenseUntilYesterday(member, today);
+        int budgetOfToday = getBudgetOfToday(member, today, expenseSumUntilYesterday);
+
+        // 오늘의 지출 합계
+        Map<Category, Integer> todayExpenseSumByCategory =
+                expenseRepository.getExpenseSumByMemberBetweenDateGroupByCategory(member, today, today);
+        int expenseOfToday = 0;
+        List<FeedbackDto.CategoryExpenseDto> categoryExpenseDtos = new ArrayList<>();
+        for (Map.Entry<Category, Integer> entry : todayExpenseSumByCategory.entrySet()) {
+            Category category = entry.getKey();
+            int expenseSum = entry.getValue();
+            categoryExpenseDtos.add(new FeedbackDto.CategoryExpenseDto(category.getName(), expenseSum));
+            expenseOfToday += expenseSum;
+        }
+
+        int risk = getRisk(budgetOfToday,  expenseOfToday);
+        return new FeedbackDto(budgetOfToday, expenseOfToday, risk, categoryExpenseDtos);
+    }
+
+    // 예산을 만족하기 위해 오늘 지출 가능한 금액 제안
+    @Override
+    public ExpenseRecommendDto getRecommendExpenseOfToday(Member member) {
+        LocalDate today = LocalDate.now();
+        int expenseUntilYesterday = getExpenseUntilYesterday(member, today);
+        int budgetOfToday = getBudgetOfToday(member, today, expenseUntilYesterday);
+
+        // 오늘이 1일이면 첫날 멘트 반환
+        if (today.getDayOfMonth() == 1) {
+            return new ExpenseRecommendDto(budgetOfToday, ConsultingMent.START.getMent());
+        }
+
+        // 어제까지의 지출 위험도 계산
+        LocalDate yesterday = getYesterday(today);
+        Integer budgetSumOfMonth = budgetRepository.getAmountSumByMember(member);
+        int budgetUntilYesterday = (budgetSumOfMonth / yesterday.lengthOfMonth()) * yesterday.getDayOfMonth();
+        int risk = getRisk(budgetUntilYesterday, expenseUntilYesterday);
+
+        ConsultingMent ment;
+        if (risk >= 120) {
+            ment = ConsultingMent.OVER;
+        } else if (risk >= 105) {
+            ment = ConsultingMent.ALMOST;
+        } else if (risk >= 95) {
+            ment = ConsultingMent.GOOD;
+        } else {
+            ment = ConsultingMent.SAVING;
+        }
+
+        return new ExpenseRecommendDto(budgetOfToday, ment.getMent());
+    }
+
+    private int getBudgetOfToday(Member member, LocalDate today, int expenseBefore) {
+        Integer budgetSum = budgetRepository.getAmountSumByMember(member);
+        if (budgetSum == null || budgetSum == 0) {
+            throw new CustomException(ErrorCode.NO_BUDGET);
+        }
+
+        int restBudget = budgetSum - expenseBefore;
+        int restDay = getRestDayThisMonth(today);
+        if (restBudget > 0) {
+            return Integer.max(MIN_BUDGET_OF_DAY,((restBudget / restDay) / 1000) * 1000);
+        } else {
+            return MIN_BUDGET_OF_DAY;
+        }
+    }
+
+    // 어제까지의 지출 구하기 (오늘이 1일이면 0원)
+    private int getExpenseUntilYesterday(Member member, LocalDate today) {
+        if (today.getDayOfMonth() == 1) {
+            return 0;
+        }
+        Map<Category, Integer> beforeExpenseSumByCategory =
+                expenseRepository.getExpenseSumByMemberBetweenDateGroupByCategory(
+                        member,
+                        getFirstDateOfMonth(today),
+                        getYesterday(today)
+                );
+        return beforeExpenseSumByCategory.values().stream().mapToInt(it -> it).sum();
+    }
+
+    private int getRisk(int budget, int expense) {
+        return (int) (((double) expense / budget) * 100);
+    }
+
+    private LocalDate getFirstDateOfMonth(LocalDate today) {
+        return today.withDayOfMonth(1);
+    }
+
+    private LocalDate getYesterday(LocalDate today) {
+        return today.minusDays(1);
+    }
+
+    private int getRestDayThisMonth(LocalDate today) {
+        return today.lengthOfMonth() - today.getDayOfMonth() + 1;
+    }
+}

--- a/src/main/java/com/wonjung/budget/type/ConsultingMent.java
+++ b/src/main/java/com/wonjung/budget/type/ConsultingMent.java
@@ -1,0 +1,20 @@
+package com.wonjung.budget.type;
+
+public enum ConsultingMent {
+    START("이번 달도 절약 도전!"),
+    GOOD("지출을 잘 조절하고 계세요! 앞으로도 화이팅!"),
+    SAVING("절약을 잘 실천하고 계세요! 오늘도 절약 도전!"),
+    ALMOST("절약까지 한걸음 남았네요! 오늘도 화이팅!"),
+    OVER("예상보다 지출이 많았네요. 오늘은 절약해보는게 어떨까요? ")
+    ;
+
+    private final String ment;
+
+    ConsultingMent(String ment) {
+        this.ment = ment;
+    }
+
+    public String getMent() {
+        return ment;
+    }
+}

--- a/src/test/java/com/wonjung/budget/controller/ConsultingControllerTest.java
+++ b/src/test/java/com/wonjung/budget/controller/ConsultingControllerTest.java
@@ -1,0 +1,174 @@
+package com.wonjung.budget.controller;
+
+import com.wonjung.budget.conmmon.ControllerTestWithAuth;
+import com.wonjung.budget.dto.request.BudgetCreateDto;
+import com.wonjung.budget.dto.request.ExpenseCreateDto;
+import com.wonjung.budget.entity.Category;
+import com.wonjung.budget.entity.Member;
+import com.wonjung.budget.exception.ErrorCode;
+import com.wonjung.budget.repository.BudgetRepository;
+import com.wonjung.budget.repository.CategoryRepository;
+import com.wonjung.budget.repository.MemberRepository;
+import com.wonjung.budget.service.BudgetService;
+import com.wonjung.budget.service.ExpenseService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ConsultingControllerTest extends ControllerTestWithAuth {
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private BudgetRepository budgetRepository;
+    @Autowired
+    private BudgetService budgetService;
+    @Autowired
+    private ExpenseService expenseService;
+
+    private Map<Long, Category> categories;
+    private Member member;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        categories = categoryRepository.findAll()
+                .stream().collect(
+                        Collectors.toMap(
+                                Category::getId,
+                                it -> it
+                        )
+                );
+        member = memberRepository.findById(memberId).get();
+    }
+
+    @Test
+    @DisplayName("오늘의 지출 안내 - 성공")
+    public void get_feedback_of_today() throws Exception {
+        // given
+        createBudgets();
+        createExpenses();
+
+        //when & then
+        mockMvc.perform(get("/api/expenses/todays-feedback")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.budget").isNumber())
+                .andExpect(jsonPath("$.expense").isNumber())
+                .andExpect(jsonPath("$.risk").isNumber())
+                .andExpect(jsonPath("$.categories").isArray())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("오늘의 지출 안내 - 예산이 설정되지 않음")
+    public void get_feedback_of_today_no_budget() throws Exception {
+        // given
+        createExpenses();
+
+        //when & then
+        mockMvc.perform(get("/api/expenses/todays-feedback")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error_code").value(ErrorCode.NO_BUDGET.name()))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("오늘의 지출 추천 - 성공")
+    public void get_recommend_of_today() throws Exception {
+        // given
+        createBudgets();
+        createExpenses();
+
+        //when & then
+        mockMvc.perform(get("/api/expenses/todays-recommend")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.budget").isNumber())
+                .andExpect(jsonPath("$.ment").isString())
+                .andDo(print());
+    }
+
+    private void createBudgets() {
+        List<BudgetCreateDto.BudgetDto> budgetDtos = categories.keySet().stream().map(categoryId ->
+                new BudgetCreateDto.BudgetDto(categoryId, (int) (10000 * categoryId))
+        ).toList();
+        BudgetCreateDto createDto = new BudgetCreateDto(budgetDtos);
+        budgetService.createOrUpdate(member, createDto);
+    }
+
+    private void createExpenses() {
+        expenseService.create(member,
+                ExpenseCreateDto.builder()
+                        .expendedAt(LocalDateTime.of(2023, 11, 9, 17, 12, 0))
+                        .category("식비")
+                        .amount(12000)
+                        .memo("점심으로 마라탕")
+                        .isExcludedSum(false)
+                        .build());
+        expenseService.create(member,
+                ExpenseCreateDto.builder()
+                        .expendedAt(LocalDateTime.of(2023, 11, 1, 17, 12, 0))
+                        .category("식비")
+                        .amount(13000)
+                        .memo("저녁으로 마라탕")
+                        .isExcludedSum(false)
+                        .build());
+        expenseService.create(member,
+                ExpenseCreateDto.builder()
+                        .expendedAt(LocalDateTime.of(2023, 10, 31, 10, 32, 0))
+                        .category("교통")
+                        .amount(3000)
+                        .memo("강남 약속")
+                        .isExcludedSum(false)
+                        .build());
+        expenseService.create(member,
+                ExpenseCreateDto.builder()
+                        .expendedAt(LocalDateTime.now())
+                        .category("생활")
+                        .amount(2000)
+                        .memo("다이소")
+                        .isExcludedSum(false)
+                        .build());
+        expenseService.create(member,
+                ExpenseCreateDto.builder()
+                        .expendedAt(LocalDateTime.now())
+                        .category("기타")
+                        .amount(2000000)
+                        .memo("엄마한테 이체")
+                        .isExcludedSum(true)
+                        .build());
+        expenseService.create(member,
+                ExpenseCreateDto.builder()
+                        .expendedAt(LocalDateTime.now())
+                        .category("교통")
+                        .amount(12300)
+                        .memo("시외버스 예매 (청주 마라탕 투어)")
+                        .isExcludedSum(false)
+                        .build());
+        expenseService.create(member,
+                ExpenseCreateDto.builder()
+                        .expendedAt(LocalDateTime.now())
+                        .category("식비")
+                        .amount(4500)
+                        .memo("편의점에서 까까")
+                        .isExcludedSum(false)
+                        .build());
+    }
+}


### PR DESCRIPTION
### 작업 개요

- 지출 컨설팅 API 구현

### 작업 분류

- 신규 기능

### 작업 상세 내용

- 오늘의 지출액 추천 API 및 로직 구현
- 오늘의 지출 피트백 API 및 로직 구현
- 통합 테스트 작성

### 테스트
- [X] 테스트 코드
- [X] API 테스트


### 생각해볼 문제
- 추후 사용자에게 알림 발송 기능 추가할 수 있음